### PR TITLE
Add GitHub CLI to Codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/BitBuilder-ai/devcontainer/cli:0.0.5": {}
+		"ghcr.io/BitBuilder-ai/devcontainer/cli:0.0.5": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 		
 	"portsAttributes": {


### PR DESCRIPTION
This allows us to open up the listener port via:
```
gh codespace ports  --codespace $CODESPACE_NAME visibility 65455:public
```